### PR TITLE
Fix crash on app reboot. Standardise indentation.

### DIFF
--- a/defos/src/defos.cpp
+++ b/defos/src/defos.cpp
@@ -103,6 +103,7 @@ dmExtension::Result AppInitializeDefos(dmExtension::AppParams* params)
 
 dmExtension::Result InitializeDefos(dmExtension::Params* params)
 {
+    defos_init();
     LuaInit(params->m_L);
     return dmExtension::RESULT_OK;
 }
@@ -114,6 +115,7 @@ dmExtension::Result AppFinalizeDefos(dmExtension::AppParams* params)
 
 dmExtension::Result FinalizeDefos(dmExtension::Params* params)
 {
+    defos_final();
     return dmExtension::RESULT_OK;
 }
 

--- a/defos/src/defos.cpp
+++ b/defos/src/defos.cpp
@@ -44,7 +44,7 @@ static int set_window_size(lua_State* L) {
 }
 
 static int set_window_title(lua_State* L) {
-	const char* title_lua = luaL_checkstring(L, 1);
+    const char* title_lua = luaL_checkstring(L, 1);
     defos_set_window_title(title_lua);
     return 0;
 }
@@ -56,7 +56,7 @@ static int toggle_fullscreen(lua_State* L) {
 
 static int is_fullscreen(lua_State* L) {
     bool isFullScreen = defos_is_fullscreen();
-	lua_pushboolean(L, isFullScreen);
+    lua_pushboolean(L, isFullScreen);
     return 1;
 }
 
@@ -80,9 +80,9 @@ static const luaL_reg Module_methods[] =
     {"disable_mouse_cursor", disable_mouse_cursor},
     {"enable_mouse_cursor", enable_mouse_cursor},
     {"set_window_size", set_window_size},
-	{"set_window_title", set_window_title},
-	{"toggle_fullscreen", toggle_fullscreen},
-	{"is_fullscreen", is_fullscreen},
+    {"set_window_title", set_window_title},
+    {"toggle_fullscreen", toggle_fullscreen},
+    {"is_fullscreen", is_fullscreen},
     {"toggle_maximize", toggle_maximize},
     {"is_maximized", is_maximized},
     {0, 0}

--- a/defos/src/defos.mm
+++ b/defos/src/defos.mm
@@ -5,29 +5,27 @@
 #include <AppKit/AppKit.h>
 #include <CoreGraphics/CoreGraphics.h>
 
-NSWindow* window;
+NSWindow* window = NULL;
 
 bool is_maximized = false;
 NSRect previous_state;
 
-void init_window(){
-    if (window == NULL) {
-        window = dmGraphics::GetNativeOSXNSWindow();
-    }
+void defos_init() {
+    window = dmGraphics::GetNativeOSXNSWindow();
+}
+
+void defos_final() {
 }
 
 void defos_disable_maximize_button() {
-    init_window();
     [[window standardWindowButton:NSWindowZoomButton] setHidden:YES];
 }
 
 void defos_disable_minimize_button() {
-    init_window();
     [[window standardWindowButton:NSWindowMiniaturizeButton] setHidden:YES];
 }
 
 void defos_disable_window_resize() {
-    init_window();
     [window setStyleMask:[window styleMask] & ~NSResizableWindowMask];
 }
 
@@ -43,7 +41,6 @@ void defos_toggle_fullscreen() {
     if (is_maximized){
         defos_toggle_maximize();
     }
-    init_window();
     [window setCollectionBehavior:NSWindowCollectionBehaviorFullScreenPrimary];
     [window toggleFullScreen:window];
 }
@@ -65,7 +62,6 @@ void defos_toggle_maximize() {
 }
 
 bool defos_is_fullscreen() {
-    init_window();
     BOOL fullscreen = (([window styleMask] & NSFullScreenWindowMask) == NSFullScreenWindowMask);
     return fullscreen == YES;
 }
@@ -75,14 +71,12 @@ bool defos_is_maximized() {
 }
 
 void defos_set_window_size(int x, int y, int w, int h) {
-    init_window();
     // correction for result like on Windows PC
     int win_y = [[window screen] frame].size.height - h - y;
     [window setFrame:NSMakeRect(x, win_y, w , h) display:YES];
 }
 
 void defos_set_window_title(const char* title_lua) {
-    init_window();
     NSString* title = [NSString stringWithUTF8String:title_lua];
     [window setTitle:title];
 }

--- a/defos/src/defos.mm
+++ b/defos/src/defos.mm
@@ -43,8 +43,8 @@ void defos_toggle_fullscreen() {
     if (is_maximized){
         defos_toggle_maximize();
     }
-	init_window();
-	[window setCollectionBehavior:NSWindowCollectionBehaviorFullScreenPrimary];
+    init_window();
+    [window setCollectionBehavior:NSWindowCollectionBehaviorFullScreenPrimary];
     [window toggleFullScreen:window];
 }
 
@@ -65,7 +65,7 @@ void defos_toggle_maximize() {
 }
 
 bool defos_is_fullscreen() {
-	init_window();
+    init_window();
     BOOL fullscreen = (([window styleMask] & NSFullScreenWindowMask) == NSFullScreenWindowMask);
     return fullscreen == YES;
 }
@@ -76,14 +76,14 @@ bool defos_is_maximized() {
 
 void defos_set_window_size(int x, int y, int w, int h) {
     init_window();
-	//correction for result like on Windows PC
-	int win_y = [[window screen] frame].size.height - h - y;
+    // correction for result like on Windows PC
+    int win_y = [[window screen] frame].size.height - h - y;
     [window setFrame:NSMakeRect(x, win_y, w , h) display:YES];
 }
 
 void defos_set_window_title(const char* title_lua) {
     init_window();
-	NSString* title = [NSString stringWithUTF8String:title_lua];
+    NSString* title = [NSString stringWithUTF8String:title_lua];
     [window setTitle:title];
 }
 

--- a/defos/src/defos_private.h
+++ b/defos/src/defos_private.h
@@ -2,6 +2,9 @@
 
 #include <dmsdk/sdk.h>
 
+extern void defos_init();
+extern void defos_final();
+
 extern void defos_disable_maximize_button();
 extern void defos_disable_minimize_button();
 extern void defos_disable_window_resize();
@@ -15,5 +18,3 @@ extern void defos_set_window_title(const char* title_lua);
 
 extern bool defos_is_fullscreen();
 extern bool defos_is_maximized();
-
-void init_window();

--- a/defos/src/defos_win.c
+++ b/defos/src/defos_win.c
@@ -10,97 +10,97 @@
 WINDOWPLACEMENT placement = { sizeof(placement) };
 
 bool set_window_style(LONG_PTR style) {
-	return SetWindowLongPtrA(dmGraphics::GetNativeWindowsHWND(), GWL_STYLE, style) != 0;
+    return SetWindowLongPtrA(dmGraphics::GetNativeWindowsHWND(), GWL_STYLE, style) != 0;
 }
 
 LONG_PTR get_window_style() {
-	return GetWindowLongPtrA(dmGraphics::GetNativeWindowsHWND(), GWL_STYLE);
+    return GetWindowLongPtrA(dmGraphics::GetNativeWindowsHWND(), GWL_STYLE);
 }
 
 bool defos_is_fullscreen() {
-	return !(get_window_style() & WS_OVERLAPPEDWINDOW);
+    return !(get_window_style() & WS_OVERLAPPEDWINDOW);
 }
 
 bool defos_is_maximized() {
-	return IsZoomed(dmGraphics::GetNativeWindowsHWND());
+    return IsZoomed(dmGraphics::GetNativeWindowsHWND());
 }
 
 void defos_disable_maximize_button() {
-	set_window_style(get_window_style() & ~WS_MAXIMIZEBOX);
+    set_window_style(get_window_style() & ~WS_MAXIMIZEBOX);
 }
 
 void defos_disable_minimize_button() {
-	set_window_style(get_window_style() & ~WS_MINIMIZEBOX);
+    set_window_style(get_window_style() & ~WS_MINIMIZEBOX);
 }
 
 void defos_disable_window_resize() {
-	set_window_style(get_window_style() & ~WS_SIZEBOX);
+    set_window_style(get_window_style() & ~WS_SIZEBOX);
 }
 
 void defos_disable_mouse_cursor() {
-	ShowCursor(0);
+    ShowCursor(0);
 }
 
 void defos_enable_mouse_cursor() {
-	ShowCursor(1);
+    ShowCursor(1);
 }
 
 // https://blogs.msdn.microsoft.com/oldnewthing/20100412-00/?p=14353/
 void defos_toggle_fullscreen() {
-	if(defos_is_maximized()) {
-		defos_toggle_maximize();
-	}
+    if(defos_is_maximized()) {
+        defos_toggle_maximize();
+    }
 
-	HWND window = dmGraphics::GetNativeWindowsHWND();
-	if(!defos_is_fullscreen()) {
-		MONITORINFO mi = { sizeof(mi) };
-		if(GetMonitorInfo(MonitorFromWindow(window, MONITOR_DEFAULTTOPRIMARY), &mi)) {
-			set_window_style(get_window_style() & ~WS_OVERLAPPEDWINDOW);
-			GetWindowPlacement(window, &placement);
-			SetWindowPos(window, HWND_TOP,
-				mi.rcMonitor.left,
-				mi.rcMonitor.top,
-				mi.rcMonitor.right - mi.rcMonitor.left,
-				mi.rcMonitor.bottom - mi.rcMonitor.top,
-				SWP_NOOWNERZORDER | SWP_FRAMECHANGED);
-		}
-	}
-	else {
-		set_window_style(get_window_style() | WS_OVERLAPPEDWINDOW);
-		SetWindowPlacement(window, &placement);
-		SetWindowPos(window, NULL,
-			0, 0, 0, 0,
-			SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOOWNERZORDER | SWP_FRAMECHANGED);
-	}
-	
+    HWND window = dmGraphics::GetNativeWindowsHWND();
+    if(!defos_is_fullscreen()) {
+        MONITORINFO mi = { sizeof(mi) };
+        if(GetMonitorInfo(MonitorFromWindow(window, MONITOR_DEFAULTTOPRIMARY), &mi)) {
+            set_window_style(get_window_style() & ~WS_OVERLAPPEDWINDOW);
+            GetWindowPlacement(window, &placement);
+            SetWindowPos(window, HWND_TOP,
+                mi.rcMonitor.left,
+                mi.rcMonitor.top,
+                mi.rcMonitor.right - mi.rcMonitor.left,
+                mi.rcMonitor.bottom - mi.rcMonitor.top,
+                SWP_NOOWNERZORDER | SWP_FRAMECHANGED);
+        }
+    }
+    else {
+        set_window_style(get_window_style() | WS_OVERLAPPEDWINDOW);
+        SetWindowPlacement(window, &placement);
+        SetWindowPos(window, NULL,
+            0, 0, 0, 0,
+            SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOOWNERZORDER | SWP_FRAMECHANGED);
+    }
+
 }
 
 void defos_toggle_maximize() {
-	if(defos_is_fullscreen()) {
-		defos_toggle_fullscreen();
-	}
+    if(defos_is_fullscreen()) {
+        defos_toggle_fullscreen();
+    }
 
-	HWND window = dmGraphics::GetNativeWindowsHWND();
-	if(defos_is_maximized()) {
-		SetWindowPlacement(window, &placement);
-	}
-	else {
-		GetWindowPlacement(window, &placement);
-		ShowWindow(window, SW_MAXIMIZE);
-	}
+    HWND window = dmGraphics::GetNativeWindowsHWND();
+    if(defos_is_maximized()) {
+        SetWindowPlacement(window, &placement);
+    }
+    else {
+        GetWindowPlacement(window, &placement);
+        ShowWindow(window, SW_MAXIMIZE);
+    }
 }
 
 void defos_set_window_size(int x, int y, int w, int h) {
-	if(x == -1) {
-		x = (GetSystemMetrics(SM_CXSCREEN) - w) / 2;
-		y = (GetSystemMetrics(SM_CYSCREEN) - h) / 2;
-	}
-	HWND window = dmGraphics::GetNativeWindowsHWND();
-	SetWindowPos(window, window, x, y, w, h, SWP_NOZORDER);
+    if(x == -1) {
+        x = (GetSystemMetrics(SM_CXSCREEN) - w) / 2;
+        y = (GetSystemMetrics(SM_CYSCREEN) - h) / 2;
+    }
+    HWND window = dmGraphics::GetNativeWindowsHWND();
+    SetWindowPos(window, window, x, y, w, h, SWP_NOZORDER);
 }
 
 void defos_set_window_title(const char* title_lua) {
-	SetWindowTextW(dmGraphics::GetNativeWindowsHWND(), CA2W(title_lua));
+    SetWindowTextW(dmGraphics::GetNativeWindowsHWND(), CA2W(title_lua));
 }
 
 #endif

--- a/defos/src/defos_win.c
+++ b/defos/src/defos_win.c
@@ -9,6 +9,9 @@
 // keep track of window placement when going to/from fullscreen or maximized
 WINDOWPLACEMENT placement = { sizeof(placement) };
 
+void defos_init() {}
+void defos_final() {}
+
 bool set_window_style(LONG_PTR style) {
     return SetWindowLongPtrA(dmGraphics::GetNativeWindowsHWND(), GWL_STYLE, style) != 0;
 }


### PR DESCRIPTION
There was a crash that happened if you tried to re-start the game from the editor on macOS with the game already running. In that case, Defold reused the process but the `NSWindow` handle changed and the old one kept by `init_window()` was invalid, causing crashes. I fixed it by getting the handle to the window in `InitializeDefos()`.

I also enforced indentation consistency because it tickled my OCD. 😄 

