### PR TITLE
Closing fix on Windows when toggling fullscreen

### DIFF
--- a/defos/src/defos_win.cpp
+++ b/defos/src/defos_win.cpp
@@ -110,9 +110,6 @@ void defos_toggle_fullscreen()
     {
         set_window_style(get_window_style() | WS_OVERLAPPEDWINDOW);
         SetWindowPlacement(window, &placement);
-        SetWindowPos(window, NULL,
-                     0, 0, 0, 0,
-                     SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOOWNERZORDER | SWP_FRAMECHANGED);
     }
 }
 


### PR DESCRIPTION
This code can make window close when toggling fullscreen. Removing seems
to make no obvious regression in function.

Fixes #30 