### PR TITLE
added get_parameters() 

### DIFF
--- a/defos/src/defos.cpp
+++ b/defos/src/defos.cpp
@@ -158,6 +158,22 @@ static int get_bundle_root(lua_State *L)
     return 1;
 }
 
+static int get_parameters(lua_State *L)
+{
+    dmArray<char*>* parameters = new dmArray<char*>();
+    defos_get_parameters(parameters);
+    lua_newtable(L);
+    for(int i = 0; i < parameters->Size(); i++)
+    {
+        char* param = (*parameters)[i];
+        lua_pushstring(L, param);
+        lua_rawseti(L, 1, i+1);
+        free(param);
+    }
+    delete parameters;
+    return 1;
+}
+
 // Windows console
 
 static int set_console_visible(lua_State *L)
@@ -419,6 +435,7 @@ static const luaL_reg Module_methods[] =
         {"reset_cursor", reset_cursor},
         {"set_window_icon", set_window_icon},
         {"get_bundle_root", get_bundle_root},
+        {"get_parameters", get_parameters},
         {0, 0}};
 
 static void LuaInit(lua_State *L)

--- a/defos/src/defos_html5.cpp
+++ b/defos/src/defos_html5.cpp
@@ -170,6 +170,18 @@ char* defos_get_bundle_root() {
     return bundlePath;
 }
 
+void defos_get_parameters(dmArray<char*>* parameters) {
+    char*param = (char*)EM_ASM_INT({
+        var jsString = window.location.search;
+        var lengthBytes = lengthBytesUTF8(jsString) + 1;
+        var stringOnWasmHeap = _malloc(lengthBytes);
+        stringToUTF8(jsString, stringOnWasmHeap, lengthBytes+1);
+        return stringOnWasmHeap;
+    },0);
+    parameters->OffsetCapacity(1);
+    parameters->Push(param);
+}
+
 void defos_set_window_size(float x, float y, float w, float h) {
     defos_set_view_size(x, y, w, h);
 }

--- a/defos/src/defos_mac.mm
+++ b/defos/src/defos_mac.mm
@@ -110,6 +110,17 @@ char* defos_get_bundle_root() {
     return bundlePath_lua;
 }
 
+void defos_get_parameters(dmArray<char*>* parameters) {
+    NSArray *args = [[NSProcessInfo processInfo] arguments];
+    for (int i = 0; i < [args count]; i++){
+        const char *param = [args[i] UTF8String];
+        char* lua_param = (char*)malloc(strlen(param) + 1);
+        strcpy(lua_param, param);
+        parameters->OffsetCapacity(1);
+        parameters->Push(lua_param);
+    }
+}
+
 void defos_set_window_size(float x, float y, float w, float h) {
     if (isnan(x)) {
         NSRect frame = window.screen.frame;

--- a/defos/src/defos_private.h
+++ b/defos/src/defos_private.h
@@ -52,6 +52,7 @@ extern bool defos_is_maximized();
 extern void defos_set_window_title(const char* title_lua);
 extern void  defos_set_window_icon(const char *icon_path);
 extern char* defos_get_bundle_root();
+extern void defos_get_parameters(dmArray<char*>* parameters);
 
 extern void defos_set_window_size(float x, float y, float w, float h);
 extern WinRect defos_get_window_size();

--- a/defos/src/defos_win.cpp
+++ b/defos/src/defos_win.cpp
@@ -235,6 +235,24 @@ char* defos_get_bundle_root() {
     return bundlePath;
 }
 
+void defos_get_parameters(dmArray<char*>* parameters) {
+    LPWSTR *szArglist;
+    int nArgs;
+    int i;
+    szArglist = CommandLineToArgvW(GetCommandLineW(), &nArgs);
+    if( NULL != szArglist ){
+        for( i=0; i<nArgs; i++) {
+            const wchar_t *param = szArglist[i];
+            int len = wcslen(param) + 1;
+            char* lua_param = (char*)malloc(len);
+            wcstombs(lua_param, param, len);
+            parameters->OffsetCapacity(1);
+            parameters->Push(lua_param);
+        }
+    }
+    LocalFree(szArglist);
+}
+
 WinRect defos_get_window_size()
 {
     HWND window = dmGraphics::GetNativeWindowsHWND();

--- a/example/example.gui_script
+++ b/example/example.gui_script
@@ -120,6 +120,7 @@ function init(self)
 	end
 
 	window.set_listener(window_callback)
+	pprint(defos.get_parameters())
 end
 
 local function change_mouse_label(text)


### PR DESCRIPTION
method that returns application parameters on mac, win and html5

on mac :
macos open -a "DefOS.app" --args -my_param
returns:
{
"path_to_the_app",
"-my_param"
}

on win:
DefOS.exe -my_param
returns:
{
"path_to_the_app",
"-my_param"
}

html5:
...index.html?my_param
returns:
{
"?my_param"
}