### PR TITLE
Cursor lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,14 +231,10 @@ end)
 
 ---
 
-**Set custom hardware cursors**. `cursor` can be one of the following:
-  * `nil`: Resets the cursor to default. Equivalent to `defos.reset_cursor()`.
-  * `defos.CURSOR_ARROW`
-  * `defos.CURSOR_HAND`
-  * `defos.CURSOR_CROSSHAIR`
-  * `defos.CURSOR_IBEAM`
-  * On HTML5, an URL to an image (data URLs work as well)
+**Load custom hardware cursors**. `cursor_data` must be:
+  * On HTML5, an URL to an image (data URLs work as well).
   * On Windows, a path to an `.ani` or `.cur` file on the file system.
+  * On Linux, a path to an X11 cursor file on the file system.
   * On macOS, a table of the form:  
   ```lua
   {
@@ -256,6 +252,21 @@ The hotspot is an anchor point within the image that will overlap with the
 functional position of the mouse pointer (eg. the tip of the arrow).
 
 [cursor-tiff]: https://developer.apple.com/library/content/documentation/GraphicsAnimation/Conceptual/HighResolutionOSX/Optimizing/Optimizing.html#//apple_ref/doc/uid/TP40012302-CH7-SW27
+
+```lua
+local cursor = defos.load_cursor(cursor_data)
+```
+
+---
+
+**Set custom hardware cursors**. `cursor` can be one of the following:
+  * `nil`: Resets the cursor to default. Equivalent to `defos.reset_cursor()`.
+  * `defos.CURSOR_ARROW`
+  * `defos.CURSOR_HAND`
+  * `defos.CURSOR_CROSSHAIR`
+  * `defos.CURSOR_IBEAM`
+  * A `cursor` value obtained with `defos.load_cursor()`.
+  * A `cursor_data` value that will be used to create a single-use cursor. See `defos.load_cursor()` above for supported values.
 
 ```lua
 defos.set_cursor(cursor)

--- a/defos/src/defos_linux.cpp
+++ b/defos/src/defos_linux.cpp
@@ -512,6 +512,7 @@ void * defos_load_cursor_linux(const char *filename)
 void defos_gc_custom_cursor(void * _cursor)
 {
     CustomCursor * cursor = (CustomCursor*)_cursor;
+    if (!cursor) { return; }
     cursor->ref_count -= 1;
     if (!cursor->ref_count) {
         XFreeCursor(disp, cursor->cursor);

--- a/defos/src/defos_private.h
+++ b/defos/src/defos_private.h
@@ -107,10 +107,12 @@ extern bool defos_is_cursor_clipped();
 extern void defos_set_cursor_locked(bool locked);
 extern bool defos_is_cursor_locked();
 
-extern void defos_set_custom_cursor_html5(const char *url);
-extern void defos_set_custom_cursor_win(const char *filename);
-extern void defos_set_custom_cursor_mac(dmBuffer::HBuffer buffer, float hotSpotX, float hotSpotY);
-extern void defos_set_custom_cursor_linux(const char *filename);
+extern void *defos_load_cursor_html5(const char *url);
+extern void *defos_load_cursor_win(const char *filename);
+extern void *defos_load_cursor_mac(dmBuffer::HBuffer buffer, float hotSpotX, float hotSpotY);
+extern void *defos_load_cursor_linux(const char *filename);
+extern void defos_gc_custom_cursor(void *cursor);
+extern void defos_set_custom_cursor(void *cursor);
 extern void defos_set_cursor(DefosCursor cursor);
 extern void defos_reset_cursor();
 

--- a/defos/src/defos_private.h
+++ b/defos/src/defos_private.h
@@ -27,10 +27,11 @@ typedef enum {
 } DefosEvent;
 
 typedef enum {
-    DEFOS_CURSOR_ARROW,
+    DEFOS_CURSOR_ARROW = 0,
     DEFOS_CURSOR_CROSSHAIR,
     DEFOS_CURSOR_HAND,
     DEFOS_CURSOR_IBEAM,
+    DEFOS_CURSOR_INTMAX,
 } DefosCursor;
 
 #ifdef DM_PLATFORM_WINDOWS

--- a/defos/src/defos_win.cpp
+++ b/defos/src/defos_win.cpp
@@ -432,6 +432,7 @@ void * defos_load_cursor_win(const char *filename)
 void defos_gc_custom_cursor(void * _cursor)
 {
     CustomCursor * cursor = (CustomCursor*)_cursor;
+    if (!cursor) { return; }
     cursor->ref_count -= 1;
     if (!cursor->ref_count) {
         delete cursor;

--- a/example/example.gui_script
+++ b/example/example.gui_script
@@ -47,26 +47,26 @@ function init(self)
 	if system_name == "Linux" then
 		-- NOTE: since Defold cannot load resource without extension, we added .xcur here.
 		-- NOTE: cursor should be normal x11 cursor file that type is: image/x-xcursor
-		table.insert(self.cursors, extract_to_savefolder("cursor.xcur"))
+		table.insert(self.cursors, defos.load_cursor(extract_to_savefolder("cursor.xcur")))
 	end
 
 	if system_name == "Windows" then
 		for i, v in ipairs({"cursor_01.ani", "cursor_02.ani" }) do
 			-- load source file and write them to save folder, so that we can access them with fullpath, or you can use bundle_resource
-			table.insert(self.cursors, extract_to_savefolder(v))
+			table.insert(self.cursors, defos.load_cursor(extract_to_savefolder(v)))
 		end
 	end
 
 	if system_name == "Darwin" then
-		table.insert(self.cursors, {
+		table.insert(self.cursors, defos.load_cursor({
 			image = resource.load("/resources/cursor_mac.tiff"),
 			hot_spot_x = 18,
 			hot_spot_y = 2,
-		})
+		}))
 	end
 
 	if system_name == "HTML5" then
-		table.insert(self.cursors, cursor_url)
+		table.insert(self.cursors, defos.load_cursor(cursor_url))
 	end
 
 	defos.on_mouse_enter(function ()


### PR DESCRIPTION
I implemented some memory management for cursors in the form of `defos.load_cursor()`, which allows you to pre-load a cursor and use it repeatedly in `defos.set_cursor()` from memory.

I'm currently stranded away from Windows/Linux machines, so that part has not been tested yet for anything apart compiling successfully.