### PR TITLE
Windows: update mouse clip on WM_WINDOWPOSCHANGED.

### DIFF
--- a/defos/src/defos_win.cpp
+++ b/defos/src/defos_win.cpp
@@ -704,6 +704,10 @@ static LRESULT __stdcall custom_wndproc(HWND hwnd, UINT umsg, WPARAM wp, LPARAM 
         }
         break;
 
+    case WM_WINDOWPOSCHANGED:
+        if (is_cursor_clipped) { defos_set_cursor_clipped(true); }
+        break;
+
     case WM_ACTIVATE:
         if (wp != WA_INACTIVE)
         {


### PR DESCRIPTION
The mouse clip region doesn't get updated if you move or resize the window with key combinations (Windows-Up, Windows-Left, Windows-Right) or if you have a fullscreen toggle in your game. This fixes that by updating it on `WM_WINDOWPOSCHANGED` which gets called after the window's position, size, or z-index changse.