### PR TITLE
Fix cursor visibility on Linux (XFCE)

### DIFF
--- a/defos/src/defos_linux.cpp
+++ b/defos/src/defos_linux.cpp
@@ -23,6 +23,7 @@
 #include <X11/Xutil.h>
 #include <X11/Xos.h>
 #include <X11/cursorfont.h>
+#include <X11/extensions/Xfixes.h>
 #include <Xcursor.h>
 #include <Xrandr.h>
 
@@ -266,21 +267,11 @@ void defos_set_cursor_visible(bool visible)
     is_cursor_visible = visible;
     if (visible)
     {
-        XGrabPointer(disp, win, true, ButtonPressMask |
-                ButtonReleaseMask |
-                PointerMotionMask |
-                FocusChangeMask |
-                EnterWindowMask |
-                LeaveWindowMask, GrabModeAsync, GrabModeAsync, None,
-                current_cursor ? current_cursor->cursor : None, CurrentTime);
+		XFixesShowCursor(disp, win);
+		XFlush(disp);
     } else {
-        XGrabPointer(disp, win, true, ButtonPressMask |
-                ButtonReleaseMask |
-                PointerMotionMask |
-                FocusChangeMask |
-                EnterWindowMask |
-                LeaveWindowMask, GrabModeAsync, GrabModeAsync, None,
-                invisible_cursor, CurrentTime);
+		XFixesHideCursor(disp, win);
+		XFlush(disp);
     }
 }
 

--- a/defos/src/defos_linux.cpp
+++ b/defos/src/defos_linux.cpp
@@ -262,11 +262,7 @@ void defos_disable_window_resize()
 }
 
 static void apply_cursor() {
-    Cursor cursor = is_cursor_visible
-        ? (current_cursor ? current_cursor->cursor : None)
-        : invisible_cursor;
-
-    // XGrabPointer(disp, win, true, 0, GrabModeAsync, GrabModeAsync, None, cursor, CurrentTime);
+    Cursor cursor = current_cursor ? current_cursor->cursor : None;
     XDefineCursor(disp, win, cursor);
 }
 
@@ -275,14 +271,12 @@ void defos_set_cursor_visible(bool visible)
     if (visible == is_cursor_visible) { return; }
     is_cursor_visible = visible;
 
-    if (visible)
-    {
+    if (visible) {
 		    XFixesShowCursor(disp, win);
-		    XFlush(disp);
     } else {
 		    XFixesHideCursor(disp, win);
-		    XFlush(disp);
     }
+    XFlush(disp);
 }
 
 bool defos_is_cursor_visible()

--- a/defos/src/defos_linux.cpp
+++ b/defos/src/defos_linux.cpp
@@ -66,7 +66,6 @@ struct CustomCursor {
 static CustomCursor * current_cursor;
 static CustomCursor * default_cursors[DEFOS_CURSOR_INTMAX];
 
-static Cursor invisible_cursor;
 static bool is_cursor_visible = true;
 static bool resize_locked = false;
 
@@ -95,17 +94,6 @@ void defos_init()
     NET_FRAME_EXTENTS = XATOM("_NET_FRAME_EXTENTS");
 
     resize_locked = false;
-
-    // Create invisible cursor
-    Pixmap bitmapNoData;
-    XColor black;
-    static char noData[] = { 0,0,0,0,0,0,0,0 };
-    black.red = black.green = black.blue = 0;
-
-    bitmapNoData = XCreateBitmapFromData(disp, win, noData, 8, 8);
-    invisible_cursor = XCreatePixmapCursor(disp, bitmapNoData, bitmapNoData, &black, &black, 0, 0);
-    XFreePixmap(disp, bitmapNoData);
-
     is_cursor_visible = true;
 
     current_cursor = NULL;
@@ -114,7 +102,6 @@ void defos_init()
 
 void defos_final()
 {
-    XFreeCursor(disp, invisible_cursor);
     defos_gc_custom_cursor(current_cursor);
     for (int i = 0; i < DEFOS_CURSOR_INTMAX; i++) {
         defos_gc_custom_cursor(default_cursors[i]);
@@ -517,7 +504,7 @@ void * defos_load_cursor_linux(const char *filename)
       cursor->cursor = XcursorImageLoadCursor(disp, image);
       XcursorImageDestroy(image);
     } else {
-      cursor->cursor = invisible_cursor;
+      cursor->cursor = XCreateFontCursor(disp, XC_left_ptr);
     }
     cursor->ref_count = 1;
     return cursor;

--- a/defos/src/defos_linux.cpp
+++ b/defos/src/defos_linux.cpp
@@ -266,9 +266,21 @@ void defos_set_cursor_visible(bool visible)
     is_cursor_visible = visible;
     if (visible)
     {
-        XDefineCursor(disp, win, current_cursor ? current_cursor->cursor : None);
+        XGrabPointer(disp, win, true, ButtonPressMask |
+                ButtonReleaseMask |
+                PointerMotionMask |
+                FocusChangeMask |
+                EnterWindowMask |
+                LeaveWindowMask, GrabModeAsync, GrabModeAsync, None,
+                current_cursor ? current_cursor->cursor : None, CurrentTime);
     } else {
-        XDefineCursor(disp, win, invisible_cursor);
+        XGrabPointer(disp, win, true, ButtonPressMask |
+                ButtonReleaseMask |
+                PointerMotionMask |
+                FocusChangeMask |
+                EnterWindowMask |
+                LeaveWindowMask, GrabModeAsync, GrabModeAsync, None,
+                invisible_cursor, CurrentTime);
     }
 }
 


### PR DESCRIPTION
Hiding the cursor was broken on Linux (XFCE), perhaps other flavors as well.
This uses `XGrabPointer` to set the cursor visibility. The `event_mask` contains a few events, I'm not sure if they are enough or are even needed.
Needs testing on other flavors to make sure it didn't break.