### PR TITLE
Implement cursor clipping on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ defos.set_cursor_pos_view(x, y) -- In game view coordinates
 
 **Clip cursor** to current game view area.
 
-Not supported on Linux and HTML5.
+Not supported on HTML5.
 
 ```lua
 defos.set_cursor_clipped(bool_value)

--- a/defos/src/defos_linux.cpp
+++ b/defos/src/defos_linux.cpp
@@ -69,6 +69,8 @@ static Cursor invisible_cursor;
 static bool is_cursor_visible = true;
 static bool resize_locked = false;
 
+static bool is_cursor_clipped = false;
+
 static bool is_window_visible(Window window);
 static void send_message(Window &window, Atom type, long a, long b, long c, long d, long e);
 
@@ -479,12 +481,31 @@ void defos_set_cursor_pos_view(float x, float y)
 
 void defos_set_cursor_clipped(bool clipped)
 {
-    dmLogWarning("Method 'set_cursor_clipped' is not supported on Linux");
+    if (clipped == is_cursor_clipped) { return; }
+    is_cursor_clipped = clipped;
+    if (clipped)
+    {
+        XGrabPointer(disp, win, true, ButtonPressMask |
+                ButtonReleaseMask |
+                PointerMotionMask |
+                FocusChangeMask |
+                EnterWindowMask |
+                LeaveWindowMask, GrabModeAsync, GrabModeAsync, win,
+                current_cursor ? current_cursor->cursor : None, CurrentTime);
+    } else {
+        XGrabPointer(disp, win, true, ButtonPressMask |
+                ButtonReleaseMask |
+                PointerMotionMask |
+                FocusChangeMask |
+                EnterWindowMask |
+                LeaveWindowMask, GrabModeAsync, GrabModeAsync, None,
+                current_cursor ? current_cursor->cursor : None, CurrentTime) ;
+    };
 }
 
 bool defos_is_cursor_clipped()
 {
-    return false;
+    return is_cursor_clipped;
 }
 
 void defos_set_cursor_locked(bool locked)

--- a/defos/src/defos_linux.cpp
+++ b/defos/src/defos_linux.cpp
@@ -108,6 +108,7 @@ void defos_init()
     XFreePixmap(disp, bitmapNoData);
 
     is_cursor_visible = true;
+    is_cursor_clipped = false;
 
     current_cursor = NULL;
     memset(default_cursors, 0, DEFOS_CURSOR_INTMAX * sizeof(CustomCursor*));

--- a/defos/src/defos_linux.cpp
+++ b/defos/src/defos_linux.cpp
@@ -13,7 +13,6 @@
 /* TODO:
  ON_MOUSE_ENTER / ON_MOUSE_LEAVE
  cursor locking
- cursor clipping
  setting the window icon
 */
 


### PR DESCRIPTION
Uses `XGrabPointer` to clip to current window.
Same thing as #101 -- I don't know if the `event_mask` bits supplied are sufficient or needed.
Should probably squash on merge.