### PR TITLE
Create defos.script_api

### DIFF
--- a/defos/defos.script_api
+++ b/defos/defos.script_api
@@ -1,0 +1,10 @@
+- name: defos
+  type: table
+  desc: The Defos extension provides functions to manage windows, cursors, displays, and events in the Defold game engine. It allows for advanced control over window properties, mouse events, and display configurations.
+
+  members:
+  - name: disable_maximize_button
+    type: function
+    desc: Disables the maximize button on the window.
+    examples:
+    - desc: Disables the maximize button, preventing users from maximizing the window.


### PR DESCRIPTION
It resolves the issue of the warnings that appear in the linter due to not finding the extension globally, but it doesn't fix the display of the complete list of functions. Many thanks to Magna for the help.