### PR TITLE
Create ext.properties

### DIFF
--- a/defos/ext.properties
+++ b/defos/ext.properties
@@ -1,0 +1,16 @@
+[defos]
+title = DefOS
+group = Runtime
+help = Settings for DefOS extension
+
+view_width.type = integer
+view_width.default = -1
+
+view_height.type = integer
+view_height.default = -1
+
+view_x.type = integer
+view_x.default = -1
+
+view_y.type = integer
+view_y.default = -1


### PR DESCRIPTION
[Soon](https://github.com/defold/defold/pull/11125), it will be possible to show extension settings in `game.project` form. This PR adds `ext.properties` that configure the extension:
<img width="642" height="782" alt="Screenshot 2025-08-22 at 15 17 06" src="https://github.com/user-attachments/assets/c3c8283c-699a-40f0-8be9-4c46fa070841" />
